### PR TITLE
Updated README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,14 @@
 
 This repository serves as a place to report issues with [GrapheneOS](https://grapheneos.org/). To open an issue, please see the [issue tracker](https://github.com/GrapheneOS/os-issue-tracker/issues).
 
-To report issues for other standalone projects, please use their respective issue trackers, listed here:
-- [hardened_malloc](https://github.com/GrapheneOS/hardened_malloc)
-- [Setup wizard](https://github.com/GrapheneOS/platform_packages_apps_SetupWizard2/issues)
-- [Talkback](https://github.com/GrapheneOS/talkback/issues)
-- [Update client](https://github.com/GrapheneOS/platform_packages_apps_Updater/issues)
-
-To report issues for standalone apps, please use their respective issue trackers, listed here:
+To report issues for **GrapheneOS apps**, please use their respective issue trackers, listed here:
 - [App Store](https://github.com/GrapheneOS/AppStore/issues)
 - [Auditor](https://github.com/GrapheneOS/Auditor/issues)
 - [GrapheneOS Camera](https://github.com/GrapheneOS/Camera/issues)
 - [PDF Viewer](https://github.com/GrapheneOS/PdfViewer/issues)
 - [Vanadium](https://github.com/GrapheneOS/Vanadium/issues)
 
-To report issues for GrapheneOS services, please use their respective issue trackers, listed here:
+To report issues for **GrapheneOS services**, please use their respective issue trackers, listed here:
 - [App repository](https://github.com/GrapheneOS/apps.grapheneos.org/issues)
 - [AttestationServer](https://github.com/GrapheneOS/AttestationServer/issues)
 - [Connectivity check & time server](https://github.com/GrapheneOS/grapheneos.network/issues)
@@ -25,3 +19,9 @@ To report issues for GrapheneOS services, please use their respective issue trac
 - [Server infrastructure](https://github.com/GrapheneOS/infrastructure/issues)
 - [Update server](https://github.com/GrapheneOS/releases.grapheneos.org/issues)
 - [Website](https://github.com/GrapheneOS/grapheneos.org/issues)
+
+To report issues for **other standalone projects**, please use their respective issue trackers, listed here:
+- [hardened_malloc](https://github.com/GrapheneOS/hardened_malloc)
+- [Setup wizard](https://github.com/GrapheneOS/platform_packages_apps_SetupWizard2/issues)
+- [Talkback](https://github.com/GrapheneOS/talkback/issues)
+- [Update client](https://github.com/GrapheneOS/platform_packages_apps_Updater/issues)


### PR DESCRIPTION
The current README.md file provides little information about what this repo is for, especially for users who find this repo without knowing about GrapheneOS. This updated version provides a brief description with helpful links to other related issue trackers. Ideally work could be done to fully flesh the README.md file, but this is a step forward.