### PR TITLE
Add link to the Dialer app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To report issues for **standalone apps**, please use their respective issue trac
 - [App Store](https://github.com/GrapheneOS/AppStore/issues)
 - [Auditor](https://github.com/GrapheneOS/Auditor/issues)
 - [Camera](https://github.com/GrapheneOS/Camera/issues)
+- [Dialer](https://github.com/GrapheneOS/platform_packages_apps_Dialer)
 - [Info](https://github.com/GrapheneOS/Info/issues)
 - [Messaging](https://github.com/GrapheneOS/Messaging/issues)
 - [PDF Viewer](https://github.com/GrapheneOS/PdfViewer/issues)


### PR DESCRIPTION
Added a link to the Dialer app. The dialer currently does not have the issues section enabled, so the link is to the main repository. Hopefully this will increase community involvement with the dialer.